### PR TITLE
Adapted tests to handle the removal of a variable from the on-demand-call-activity plugin.

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -644,8 +644,8 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().list();
 
     // assume
-    // OnDemandCallActivity generates two more variables...
-    assertThat(historicVariableInstances.size(), is(1 + 2));
+    // OnDemandCallActivity generates one more variable...
+    assertThat(historicVariableInstances.size(), is( 2));
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
@@ -1024,10 +1024,10 @@ public class BoundaryConditionalEventTest extends AbstractConditionalEventTestCa
     //then out mapping of call activity sets a variable
     //-> non interrupting conditional event is triggered
 
-    /* Changed the number of tasks due to the fact that the conditional event triggers 3 times, since we have three variables
+    /* Changed the number of tasks due to the fact that the conditional event triggers 2 times, since we have two variables
     and the conditional event is not filtering any variables */
     tasksAfterVariableIsSet = taskQuery.list();
-    assertEquals(4, tasksAfterVariableIsSet.size());
+    assertEquals(3, tasksAfterVariableIsSet.size());
     assertEquals(0, conditionEventSubscriptionQuery.count());
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/conditional/MixedConditionalEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/conditional/MixedConditionalEventTest.java
@@ -838,10 +838,10 @@ public class MixedConditionalEventTest extends AbstractConditionalEventTestCase 
 
     //then out mapping of call activity sets a variable
     //-> all non interrupting conditional events are triggered
-    /* Changed the number of tasks due to the fact that the conditional event triggers 3 times, since we have three variables
+    /* Changed the number of tasks due to the fact that the conditional event triggers 2 times, since we have two variables
     and the conditional event is not filtering any variables */
     tasksAfterVariableIsSet = taskQuery.list();
-    assertEquals(7, tasksAfterVariableIsSet.size());
+    assertEquals(6, tasksAfterVariableIsSet.size());
     //three subscriptions: event sub process in sub process and on process instance level and boundary event of sub process
     assertEquals(3, conditionEventSubscriptionQuery.count());
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricVariableInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricVariableInstanceTest.java
@@ -211,15 +211,15 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTestCase
     runtimeService.signal(callActivityExecution.getId());
     assertProcessEnded(processInstance.getId());
 
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().count());
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().list().size());
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().count());
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().list().size());
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().count());
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().list().size());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().count());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().list().size());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().count());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().list().size());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().count());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().list().size());
 
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
-    assertEquals(4, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list().size());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count());
+    assertEquals(3, historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list().size());
     assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableName("myVar").count());
     assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableName("myVar").list().size());
     assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableNameLike("myVar1").count());
@@ -227,7 +227,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTestCase
     /*assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableNameLike("my\\_Var%").count());
     assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableNameLike("my\\_Var%").list().size());*/
     List<HistoricVariableInstance> variables = historyService.createHistoricVariableInstanceQuery().list();
-    assertEquals(4, variables.size());
+    assertEquals(3, variables.size());
 
     assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test123").count());
     assertEquals(1, historyService.createHistoricVariableInstanceQuery().variableValueEquals("myVar", "test123").list().size());
@@ -241,7 +241,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTestCase
     assertEquals(5, historyService.createHistoricActivityInstanceQuery().count());
 
     if (isFullHistoryEnabled()) {
-      assertEquals(6, historyService.createHistoricDetailQuery().count());
+      assertEquals(5, historyService.createHistoricDetailQuery().count());
     }
 
     // non-existing id:


### PR DESCRIPTION
@dependabot rebase