### PR TITLE
Skip lookup of process definition on key=null

### DIFF
--- a/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/DefinitionKeyNullValueException.java
+++ b/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/DefinitionKeyNullValueException.java
@@ -1,0 +1,28 @@
+package org.camunda.bpm.extension.bpmn.callactivity.ondemand.plugin;
+
+import org.camunda.bpm.engine.exception.NullValueException;
+
+/**
+ * @author Falko Menge
+ */
+public class DefinitionKeyNullValueException extends NullValueException {
+
+  private static final long serialVersionUID = 1L;
+
+  public DefinitionKeyNullValueException() {
+    super();
+  }
+
+  public DefinitionKeyNullValueException(String message) {
+    super(message);
+  }
+
+  public DefinitionKeyNullValueException(Throwable cause) {
+    super(cause);
+  }
+
+  public DefinitionKeyNullValueException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/OnDemandCallActivityParseListener.java
+++ b/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/OnDemandCallActivityParseListener.java
@@ -40,7 +40,8 @@ public class OnDemandCallActivityParseListener extends AbstractBpmnParseListener
             } else {
                 onDemandCallActivityBehavior = new OnDemandCallActivityBehavior(expression);
             }
-            onDemandCallActivityBehavior.setCallableElement(currentCallActivityBehavior.getCallableElement());
+            onDemandCallActivityBehavior.setCallableElement(
+                new OnDemandCallableElement(currentCallActivityBehavior.getCallableElement()));
             activity.setActivityBehavior(onDemandCallActivityBehavior);
 
         }

--- a/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/OnDemandCallableElement.java
+++ b/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/OnDemandCallableElement.java
@@ -1,0 +1,53 @@
+/**
+ * 
+ */
+package org.camunda.bpm.extension.bpmn.callactivity.ondemand.plugin;
+
+import org.camunda.bpm.engine.delegate.VariableScope;
+import org.camunda.bpm.engine.exception.NullValueException;
+import org.camunda.bpm.engine.impl.core.model.BaseCallableElement;
+import org.camunda.bpm.engine.impl.core.model.CallableElement;
+import org.camunda.bpm.engine.impl.util.CallableElementUtil;
+
+/**
+ * An implementation of {@link CallableElement} that throws a
+ * {@link NullValueException} as soon as possible when an empty definition key
+ * is detected. It thereby avoids unnecessary database lookups by
+ * {@link CallableElementUtil#getProcessDefinitionToCall(VariableScope, BaseCallableElement)}.
+ *
+ * @author Falko Menge (Camunda)
+ */
+public class OnDemandCallableElement extends CallableElement {
+
+  /**
+   * This constructor basically clones the given {@link CallableElement}.
+   *
+   * When updating to a new Camunda version, it MUST be verified that all
+   * fields/properties of the super classes are correctly copied over.
+   * 
+   * @param callableElement
+   */
+  public OnDemandCallableElement(CallableElement callableElement) {
+    super();
+    setDefinitionKeyValueProvider(callableElement.getDefinitionKeyValueProvider());
+    setBinding(callableElement.getBinding());
+    setVersionValueProvider(callableElement.getVersionValueProvider());
+    setVersionTagValueProvider(callableElement.getVersionTagValueProvider());
+    setTenantIdProvider(callableElement.getTenantIdProvider());
+    setDeploymentId(callableElement.getDeploymentId());
+    setBusinessKeyValueProvider(callableElement.getBusinessKeyValueProvider());
+    addInputs(callableElement.getInputs());
+    addOutputs(callableElement.getOutputs());
+    outputsLocal = (callableElement.getOutputsLocal());
+  }
+  
+  @Override
+  public String getDefinitionKey(VariableScope variableScope) {
+    String definitionKey = super.getDefinitionKey(variableScope);
+    if (definitionKey == null) {
+      throw new DefinitionKeyNullValueException("The definition key of a callable element was null.");
+    }
+    return definitionKey;
+  }
+
+}


### PR DESCRIPTION
Fixes #50 
- [x] avoid calling child process provider twice by caching its result in CallableElement