### PR TITLE
optimization of camunda process variables

### DIFF
--- a/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/AbstractChildProcessProvider.java
+++ b/engine-plugin-on-demand-call-activity/src/main/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/AbstractChildProcessProvider.java
@@ -50,12 +50,16 @@ public abstract class AbstractChildProcessProvider {
     
     String childProcess = decideOnChildProcess(execution);
     if (childProcess == null || childProcess.isEmpty()) {
-      execute(new OnDemandCallActivityExecution(execution));
+      OnDemandCallActivityExecution onDemandCallActivityExecution = new OnDemandCallActivityExecution(execution);
+      updateOnDemandCallActivityExecutionVariables(execution, onDemandCallActivityExecution);
+      execute(onDemandCallActivityExecution);
       execution.setVariableLocal(getAsyncServiceCallVarName(execution), true);
       return null;
     } else {
       return childProcess;
     }
   }
+
+    public abstract void updateOnDemandCallActivityExecutionVariables(DelegateExecution execution, OnDemandCallActivityExecution onDemandCallActivityExecution);
 
 }

--- a/engine-plugin-on-demand-call-activity/src/test/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/ChildProcessProvider.java
+++ b/engine-plugin-on-demand-call-activity/src/test/java/org/camunda/bpm/extension/bpmn/callactivity/ondemand/plugin/ChildProcessProvider.java
@@ -123,4 +123,12 @@ public class ChildProcessProvider extends AbstractChildProcessProvider {
       logger.info("ChildProcessProvider execute finished: {}", Thread.currentThread().getId());
 
     }
+
+	@Override
+	public void updateOnDemandCallActivityExecutionVariables(DelegateExecution execution,
+			OnDemandCallActivityExecution onDemandCallActivityExecution)
+	{
+		logger.info(
+				"ChildProcessProvider need to implement updateOnDemandCallActivityExecutionVariables to explicitly copy additional variables from current execution to onDemandCallActivityExecution");
+	}
 }


### PR DESCRIPTION
As part of this PR we are trying to reduce the number of variables that are being copied from top level process to every sub process. When there will be OnDemandActivityCall from subprocess, some of the variable which we required from top level process were not available to ondemandactivity which will be causing issue. To get this variable to ondemandactivity from top level process we have implemented this changes in ondemandactivitycall plugin. This PR represent the changes for the same.